### PR TITLE
test for tempfile handling an ruby 1.8.7

### DIFF
--- a/lib/rack/raw_upload.rb
+++ b/lib/rack/raw_upload.rb
@@ -29,9 +29,10 @@ module Rack
     def convert_and_pass_on(env)
       tempfile = Tempfile.new('raw-upload.', @tmpdir)
       if (RUBY_VERSION.split('.').map{|e| e.to_i} <=> [1, 9]) > 0
-        # Not sure of what's going on, or how to test this.
-        # This seems to be needed in 1.9, but people report
-        # problems if done in 1.8.7
+        # 1.8.7: if the 'original' tempfile has no open file-handler,
+        # the garbage collector will unlink this file.
+        # in this case, only the path to the 'original' tempfile is used
+        # and the physical file will be deleted, if the gc runs.
         tempfile = open(tempfile.path, "r+:BINARY")
       end
       tempfile << env['rack.input'].read

--- a/test/raw_upload_test.rb
+++ b/test/raw_upload_test.rb
@@ -63,6 +63,13 @@ class RawUploadTest < Test::Unit::TestCase
       assert_successful_non_upload
     end
 
+    should "be compatible to rails 1.8.7 and tempfile must exist after garbage collection" do
+      upload('CONTENT_TYPE' => 'application/octet-stream')
+      received = last_request.POST["file"]
+      GC.start
+      assert File.exists?(received[:tempfile].path)
+    end
+
     context "with X-File-Upload: smart" do
       should "perform a file upload if appropriate" do
         upload('CONTENT_TYPE' => 'multipart/form-data', 'HTTP_X_FILE_UPLOAD' => 'smart')


### PR DESCRIPTION
Hi Pablo,

with ruby 1.8.7, the tempfile will be deleted, if the garbage collector runs.
I have added a test for this.

Best regards,
Daniel
