### PR TITLE
Rewind rack.input after reading from it

### DIFF
--- a/lib/rack/raw_upload.rb
+++ b/lib/rack/raw_upload.rb
@@ -44,6 +44,7 @@ module Rack
             tempfile << chunk
           end
         end
+        env['rack.input'].rewind
 
         tempfile.flush
         tempfile.rewind


### PR DESCRIPTION
If we don't rewind rack.input after reading from it, other rack middlewares will get empty string when trying to read from rack.input.
